### PR TITLE
No more need of kCallerPasses_Ownership  (2/2)

### DIFF
--- a/media/jni/android_media_ExifInterface.cpp
+++ b/media/jni/android_media_ExifInterface.cpp
@@ -390,8 +390,7 @@ static jobject ExifInterface_getRawAttributesFromFileDescriptor(
     // Rewind the file descriptor.
     fseek(file, 0L, SEEK_SET);
 
-    std::unique_ptr<SkFILEStream> fileStream(new SkFILEStream(file,
-                SkFILEStream::kCallerPasses_Ownership));
+    std::unique_ptr<SkFILEStream> fileStream(new SkFILEStream(file));
     return getRawAttributes(env, fileStream.get(), false);
 }
 


### PR DESCRIPTION
Fixes Compiling error!
Bug: 65646012
Bug: 65426286

Cherry-picked from master. The original CL just updates BitmapFactory.
This also updates ExifInterface in the same way. ExifInterface.cpp no
longer existed by the time the Skia change landed.

Required for Ib7aaf367f68f8764147887d858f65ee14fa7a1d9, which fixes
the aforementioned bugs.

Test: No change in behavior, no new tests.

This enum is going away in https://skia-review.googlesource.com/c/9498,
and this method is using the default anyway.

Merged-In: I928a72851f90e84f45ce2fa49560f8ba894a8058
Merged-In: I8f6c761e50cb29476dc0784f58908ec35e3c70e9
Change-Id: I928a72851f90e84f45ce2fa49560f8ba894a8058
(cherry picked from commit adb5e0b)